### PR TITLE
fix: set query and page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -67,7 +67,6 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-
   final _searchTextController = TextEditingController();
 
   final _productsSearcher = HitsSearcher(
@@ -79,7 +78,7 @@ class _MyHomePageState extends State<MyHomePage> {
       _productsSearcher.responses.map(SearchMetadata.fromResponse);
 
   final PagingController<int, Product> _pagingController =
-  PagingController(firstPageKey: 0);
+      PagingController(firstPageKey: 0);
 
   Stream<HitsPage> get _searchPage =>
       _productsSearcher.responses.map(HitsPage.fromResponse);
@@ -96,8 +95,16 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void initState() {
     super.initState();
-    _searchTextController
-        .addListener(() => _productsSearcher.query(_searchTextController.text));
+
+    _searchTextController.addListener(
+      () => _productsSearcher.applyState(
+        (state) => state.copyWith(
+          query: _searchTextController.text,
+          page: 0,
+        ),
+      ),
+    );
+
     _searchPage.listen((page) {
       if (page.pageKey == 0) {
         _pagingController.refresh();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,14 +14,14 @@ packages:
       name: algolia_helper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.3"
   algolia_helper_flutter:
     dependency: "direct main"
     description:
       name: algolia_helper_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.3"
   async:
     dependency: transitive
     description:
@@ -108,7 +108,7 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   infinite_scroll_pagination:
     dependency: "direct main"
     description:
@@ -122,14 +122,14 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   matcher:
     dependency: transitive
     description:
@@ -164,7 +164,7 @@ packages:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.27.5"
+    version: "0.27.7"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -239,7 +239,7 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   vector_math:
     dependency: transitive
     description:


### PR DESCRIPTION
At search query update, setting the `query` only will result in appending a new page to the paging controller.
The initial page number should be set too.